### PR TITLE
feat: #197 - Network Topology Map

### DIFF
--- a/app/Http/Controllers/Api/NetworkMapController.php
+++ b/app/Http/Controllers/Api/NetworkMapController.php
@@ -1,0 +1,416 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Hardware;
+use App\Models\NetworkLink;
+use App\Models\Unit;
+use App\Services\AccessService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+
+class NetworkMapController extends Controller
+{
+    public function switches(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($user);
+
+        // Get bounding box from request
+        $bounds = $request->validate([
+            'min_lat' => 'nullable|numeric|between:-90,90',
+            'max_lat' => 'nullable|numeric|between:-90,90',
+            'min_lng' => 'nullable|numeric|between:-180,180',
+            'max_lng' => 'nullable|numeric|between:-180,180',
+        ]);
+
+        $query = Hardware::with('person.unit')
+            ->whereHas('person', function ($q) use ($accessibleIds) {
+                $q->whereIn('u_id', $accessibleIds);
+            })
+            ->whereNotNull('switch')
+            ->where('switch', '!=', '');
+
+        // Apply bounding box filter if provided
+        if (!empty($bounds['min_lat'])) {
+            $query->whereHas('person.unit', function ($q) use ($bounds) {
+                $q->whereBetween('lat', [$bounds['min_lat'], $bounds['max_lat']])
+                    ->whereBetween('lng', [$bounds['min_lng'], $bounds['max_lng']]);
+            });
+        }
+
+        $hardwares = $query->get();
+
+        // Group by switch name and aggregate
+        $switches = $hardwares->groupBy('switch')->map(function ($group, $switchName) {
+            $first = $group->first();
+            $unit = $first->person->unit ?? null;
+
+            $vlans = $group->pluck('vlan')->filter()->unique()->values();
+            $types = $group->pluck('type')->filter()->unique()->values();
+            $netTypes = $group->pluck('net_type')->filter()->unique()->values();
+
+            // Count devices
+            $deviceCount = $group->count();
+            $portCount = $group->whereNotNull('port')->where('port', '!=', '')->count();
+
+            return [
+                'type' => 'Feature',
+                'geometry' => [
+                    'type' => 'Point',
+                    'coordinates' => [
+                        (float) $unit->lng,
+                        (float) $unit->lat,
+                    ],
+                ],
+                'properties' => [
+                    'switch' => $switchName,
+                    'unit_id' => $unit->id ?? null,
+                    'unit_name' => $unit->name ?? null,
+                    'device_count' => $deviceCount,
+                    'port_count' => $portCount,
+                    'vlans' => $vlans->values(),
+                    'types' => $types->values(),
+                    'net_types' => $netTypes->values(),
+                ],
+            ];
+        })->values();
+
+        return response()->json([
+            'type' => 'FeatureCollection',
+            'features' => $switches,
+        ]);
+    }
+
+    public function links(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($user);
+
+        $query = NetworkLink::with(['sourceUnit', 'targetUnit'])
+            ->where(function ($q) use ($accessibleIds) {
+                $q->whereIn('source_unit_id', $accessibleIds)
+                    ->orWhereIn('target_unit_id', $accessibleIds);
+            });
+
+        // Apply bounding box filter
+        $bounds = $request->validate([
+            'min_lat' => 'nullable|numeric|between:-90,90',
+            'max_lat' => 'nullable|numeric|between:-90,90',
+            'min_lng' => 'nullable|numeric|between:-180,180',
+            'max_lng' => 'nullable|numeric|between:-180,180',
+        ]);
+
+        if (!empty($bounds['min_lat'])) {
+            $query->where(function ($q) use ($bounds) {
+                $q->whereHas('sourceUnit', function ($uq) use ($bounds) {
+                    $uq->whereBetween('lat', [$bounds['min_lat'], $bounds['max_lat']])
+                        ->whereBetween('lng', [$bounds['min_lng'], $bounds['max_lng']]);
+                })->orWhereHas('targetUnit', function ($uq) use ($bounds) {
+                    $uq->whereBetween('lat', [$bounds['min_lat'], $bounds['max_lat']])
+                        ->whereBetween('lng', [$bounds['min_lng'], $bounds['max_lng']]);
+                });
+            });
+        }
+
+        $links = $query->get()->map(function ($link) {
+            $source = $link->sourceUnit;
+            $target = $link->targetUnit;
+
+            return [
+                'type' => 'Feature',
+                'geometry' => [
+                    'type' => 'LineString',
+                    'coordinates' => [
+                        [(float) $source->lng, (float) $source->lat],
+                        [(float) $target->lng, (float) $target->lat],
+                    ],
+                ],
+                'properties' => [
+                    'source_switch' => $link->source_switch,
+                    'target_switch' => $link->target_switch,
+                    'link_type' => $link->link_type,
+                    'vlans' => $link->vlans ?? [],
+                    'distance_km' => $link->distance_km,
+                    'latency_ms' => $link->latency_ms,
+                    'bandwidth_mbps' => $link->bandwidth_mbps,
+                    'is_redundant' => $link->is_redundant,
+                    'source_unit' => $source ? ['id' => $source->id, 'name' => $source->name] : null,
+                    'target_unit' => $target ? ['id' => $target->id, 'name' => $target->name] : null,
+                ],
+            ];
+        });
+
+        return response()->json([
+            'type' => 'FeatureCollection',
+            'features' => $links,
+        ]);
+    }
+
+    public function vlans(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($user);
+
+        $hardwares = Hardware::with('person.unit')
+            ->whereHas('person', function ($q) use ($accessibleIds) {
+                $q->whereIn('u_id', $accessibleIds);
+            })
+            ->whereNotNull('vlan')
+            ->where('vlan', '!=', '')
+            ->get();
+
+        $vlans = $hardwares->groupBy('vlan')->map(function ($group, $vlan) {
+            $first = $group->first();
+            return [
+                'vlan' => $vlan,
+                'switch_count' => $group->pluck('switch')->filter()->unique()->count(),
+                'link_count' => $group->pluck('switch')->filter()->unique()->count(), // approximate
+                'unit_count' => $group->pluck('person.u_id')->unique()->count(),
+                'device_count' => $group->count(),
+                'color' => $this->vlanColor($vlan),
+            ];
+        })->values();
+
+        return response()->json($vlans);
+    }
+
+    public function spof(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($user);
+
+        // Get switches and count how many units each serves
+        $switches = Hardware::with('person.unit')
+            ->whereHas('person', function ($q) use ($accessibleIds) {
+                $q->whereIn('u_id', $accessibleIds);
+            })
+            ->whereNotNull('switch')
+            ->where('switch', '!=', '')
+            ->get()
+            ->groupBy('switch')
+            ->map(function ($group) {
+                $first = $group->first();
+                $unit = $first->person->unit ?? null;
+                $deviceCount = $group->count();
+                $unitCount = $group->pluck('person.u_id')->unique()->count();
+
+                // SPOF score: higher if serves many units and is not redundant
+                // For now, simple heuristic: more units = higher risk
+                $riskScore = $unitCount * 10 + $deviceCount;
+
+                return [
+                    'type' => 'Feature',
+                    'geometry' => [
+                        'type' => 'Point',
+                        'coordinates' => [
+                            (float) ($unit->lng ?? 0),
+                            (float) ($unit->lat ?? 0),
+                        ],
+                    ],
+                    'properties' => [
+                        'switch' => $group->first()->switch,
+                        'unit_id' => $unit->id ?? null,
+                        'unit_name' => $unit->name ?? null,
+                        'unit_count' => $unitCount,
+                        'device_count' => $deviceCount,
+                        'risk_score' => $riskScore,
+                        'risk_level' => $riskScore > 50 ? 'critical' : ($riskScore > 20 ? 'high' : 'medium'),
+                    ],
+                ];
+            })
+            ->sortByDesc('properties.risk_score')
+            ->values();
+
+        return response()->json([
+            'type' => 'FeatureCollection',
+            'features' => $switches,
+        ]);
+    }
+
+    public function trace(Request $request): JsonResponse
+    {
+        $request->validate([
+            'source' => 'required|string', // switch name or hardware id
+            'target' => 'required|string',
+        ]);
+
+        $user = $request->user();
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($user);
+
+        // This is a simplified path finding - in production would use actual network graph
+        // For now, return a simple line between the two points
+        $sourceHw = Hardware::with('person.unit')
+            ->where('switch', $request->source)
+            ->orWhere('id', $request->source)
+            ->whereHas('person', function ($q) use ($accessibleIds) {
+                $q->whereIn('u_id', $accessibleIds);
+            })
+            ->first();
+
+        $targetHw = Hardware::with('person.unit')
+            ->where('switch', $request->target)
+            ->orWhere('id', $request->target)
+            ->whereHas('person', function ($q) use ($accessibleIds) {
+                $q->whereIn('u_id', $accessibleIds);
+            })
+            ->first();
+
+        if (!$sourceHw || !$targetHw) {
+            return response()->json(['error' => 'Source or target not found'], 404);
+        }
+
+        $sourceUnit = $sourceHw->person->unit;
+        $targetUnit = $targetHw->person->unit;
+
+        $path = [
+            'type' => 'FeatureCollection',
+            'features' => [
+                [
+                    'type' => 'Feature',
+                    'geometry' => [
+                        'type' => 'LineString',
+                        'coordinates' => [
+                            [(float) $sourceUnit->lng, (float) $sourceUnit->lat],
+                            [(float) $targetUnit->lng, (float) $targetUnit->lat],
+                        ],
+                    ],
+                    'properties' => [
+                        'source' => $sourceHw->switch ?? $sourceHw->id,
+                        'target' => $targetHw->switch ?? $targetHw->id,
+                        'distance_km' => $this->calculateDistance(
+                            $sourceUnit->lat, $sourceUnit->lng,
+                            $targetUnit->lat, $targetUnit->lng
+                        ),
+                    ],
+                ],
+            ],
+        ];
+
+        return response()->json($path);
+    }
+
+    public function stats(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($user);
+
+        $stats = Cache::remember('network-map-stats:' . md5(json_encode($accessibleIds)), 300, function () use ($accessibleIds) {
+            $hardwares = Hardware::whereHas('person', function ($q) use ($accessibleIds) {
+                $q->whereIn('u_id', $accessibleIds);
+            })->get();
+
+            $switches = $hardwares->whereNotNull('switch')->where('switch', '!=', '')->pluck('switch')->unique();
+            $links = NetworkLink::where(function ($q) use ($accessibleIds) {
+                $q->whereIn('source_unit_id', $accessibleIds)
+                    ->orWhereIn('target_unit_id', $accessibleIds);
+            })->get();
+
+            $vlans = $hardwares->whereNotNull('vlan')->where('vlan', '!=', '')->pluck('vlan')->unique();
+
+            // SPOF count
+            $spofCount = 0;
+            $switchGroups = $hardwares->whereNotNull('switch')->where('switch', '!=', '')->groupBy('switch');
+            foreach ($switchGroups as $group) {
+                $unitCount = $group->pluck('person.u_id')->unique()->count();
+                if ($unitCount > 5) {
+                    $spofCount++;
+                }
+            }
+
+            return [
+                'total_switches' => $switches->count(),
+                'total_links' => $links->count(),
+                'total_vlans' => $vlans->count(),
+                'total_devices' => $hardwares->count(),
+                'spof_count' => $spofCount,
+                'avg_latency_ms' => $links->avg('latency_ms') ?? 0,
+            ];
+        });
+
+        return response()->json($stats);
+    }
+
+    public function devices(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($user);
+
+        $bounds = $request->validate([
+            'min_lat' => 'nullable|numeric|between:-90,90',
+            'max_lat' => 'nullable|numeric|between:-90,90',
+            'min_lng' => 'nullable|numeric|between:-180,180',
+            'max_lng' => 'nullable|numeric|between:-180,180',
+        ]);
+
+        $query = Hardware::with('person.unit')
+            ->whereHas('person', function ($q) use ($accessibleIds) {
+                $q->whereIn('u_id', $accessibleIds);
+            });
+
+        if (!empty($bounds['min_lat'])) {
+            $query->whereHas('person.unit', function ($q) use ($bounds) {
+                $q->whereBetween('lat', [$bounds['min_lat'], $bounds['max_lat']])
+                    ->whereBetween('lng', [$bounds['min_lng'], $bounds['max_lng']]);
+            });
+        }
+
+        $devices = $query->get()->map(function ($hw) {
+            $unit = $hw->person->unit ?? null;
+            return [
+                'type' => 'Feature',
+                'geometry' => [
+                    'type' => 'Point',
+                    'coordinates' => [
+                        (float) ($unit->lng ?? 0),
+                        (float) ($unit->lat ?? 0),
+                    ],
+                ],
+                'properties' => [
+                    'id' => $hw->id,
+                    'n_code' => $hw->n_code,
+                    'pc_name' => $hw->pc_name,
+                    'type' => $hw->type,
+                    'os' => $hw->os,
+                    'ip_valid' => $hw->ip_valid,
+                    'ip_local' => $hw->ip_local,
+                    'mac' => $hw->mac,
+                    'net_type' => $hw->net_type,
+                    'switch' => $hw->switch,
+                    'port' => $hw->port,
+                    'vlan' => $hw->vlan,
+                    'unit_name' => $unit->name ?? null,
+                    'unit_id' => $unit->id ?? null,
+                ],
+            ];
+        });
+
+        return response()->json([
+            'type' => 'FeatureCollection',
+            'features' => $devices,
+        ]);
+    }
+
+    private function vlanColor(int $vlan): string
+    {
+        $colors = [
+            1 => '#e74c3c', 10 => '#3498db', 20 => '#2ecc71', 30 => '#f39c12',
+            40 => '#9b59b6', 50 => '#1abc9c', 100 => '#e67e22', 200 => '#34495e',
+        ];
+        return $colors[$vlan] ?? '#' . substr(md5((string)$vlan), 0, 6);
+    }
+
+    private function calculateDistance(float $lat1, float $lng1, float $lat2, float $lng2): float
+    {
+        $earthRadius = 6371; // km
+        $dLat = deg2rad($lat2 - $lat1);
+        $dLng = deg2rad($lng2 - $lng1);
+        $a = sin($dLat/2) * sin($dLat/2) +
+             cos(deg2rad($lat1)) * cos(deg2rad($lat2)) *
+             sin($dLng/2) * sin($dLng/2);
+        $c = 2 * atan2(sqrt($a), sqrt(1-$a));
+        return round($earthRadius * $c, 2);
+    }
+}

--- a/app/Models/NetworkLink.php
+++ b/app/Models/NetworkLink.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class NetworkLink extends Model
+{
+    protected $fillable = [
+        'source_switch',
+        'target_switch',
+        'link_type',
+        'vlans',
+        'distance_km',
+        'latency_ms',
+        'bandwidth_mbps',
+        'is_redundant',
+        'source_unit_id',
+        'target_unit_id',
+    ];
+
+    protected $casts = [
+        'vlans' => 'array',
+        'is_redundant' => 'boolean',
+        'distance_km' => 'float',
+        'latency_ms' => 'integer',
+        'bandwidth_mbps' => 'integer',
+    ];
+
+    public function sourceUnit(): BelongsTo
+    {
+        return $this->belongsTo(Unit::class, 'source_unit_id');
+    }
+
+    public function targetUnit(): BelongsTo
+    {
+        return $this->belongsTo(Unit::class, 'target_unit_id');
+    }
+}

--- a/database/migrations/2026_08_03_003709_create_network_links_table.php
+++ b/database/migrations/2026_08_03_003709_create_network_links_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('network_links', function (Blueprint $table) {
+            $table->id();
+            $table->string('source_switch');          // From hardware.switch
+            $table->string('target_switch');          // From hardware.switch
+            $table->string('link_type')->default('unknown'); // fiber, wireless, mpls, vpn, unknown
+            $table->json('vlans')->nullable();        // ["10","20","100"]
+            $table->decimal('distance_km', 8, 2)->nullable();
+            $table->integer('latency_ms')->nullable();
+            $table->integer('bandwidth_mbps')->nullable();
+            $table->boolean('is_redundant')->default(false);
+            $table->unsignedBigInteger('source_unit_id')->nullable();
+            $table->unsignedBigInteger('target_unit_id')->nullable();
+            $table->timestamps();
+
+            $table->index('source_switch');
+            $table->index('target_switch');
+            $table->index('link_type');
+            $table->foreign('source_unit_id')->references('id')->on('units')->nullOnDelete();
+            $table->foreign('target_unit_id')->references('id')->on('units')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('network_links');
+    }
+};

--- a/resources/views/livewire/it/network-map.blade.php
+++ b/resources/views/livewire/it/network-map.blade.php
@@ -1,0 +1,382 @@
+<?php
+
+use App\Models\Hardware;
+use App\Models\NetworkLink;
+use App\Services\AccessService;
+use Livewire\Component;
+use Illuminate\Support\Facades\Cache;
+
+return new class extends Component
+{
+    public bool $showHelpModal = false;
+
+    public array $switches = [];
+    public array $links = [];
+    public array $vlans = [];
+    public array $spof = [];
+
+    public bool $showSwitches = true;
+    public bool $showLinks = true;
+    public bool $showVlans = false;
+    public bool $showDevices = false;
+    public bool $showSpof = false;
+
+    public string $selectedLinkType = '';
+    public string $selectedVlan = '';
+    public array $stats = [];
+    public bool $loading = false;
+
+    public function mount(): void
+    {
+        $this->loadData();
+        $this->loadStats();
+    }
+
+    public function loadData(): void
+    {
+        $this->loading = true;
+        $user = auth()->user();
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($user);
+
+        // Load switches
+        $switches = Hardware::with('person.unit')
+            ->whereHas('person', function ($q) use ($accessibleIds) {
+                $q->whereIn('u_id', $accessibleIds);
+            })
+            ->whereNotNull('switch')
+            ->where('switch', '!=', '')
+            ->get();
+
+        $this->switches = $switches->groupBy('switch')->map(function ($group) {
+            $first = $group->first();
+            $unit = $first->person->unit ?? null;
+
+            return [
+                'name' => $group->first()->switch,
+                'lat' => $unit->lat ?? null,
+                'lng' => $unit->lng ?? null,
+                'unit_id' => $unit->id ?? null,
+                'unit_name' => $unit->name ?? null,
+                'device_count' => $group->count(),
+                'vlans' => $group->pluck('vlan')->filter()->unique()->values(),
+            ];
+        })->values()->toArray();
+
+        // Load links from network_links table
+        $this->links = NetworkLink::with(['sourceUnit', 'targetUnit'])
+            ->where(function ($q) use ($accessibleIds) {
+                $q->whereIn('source_unit_id', $accessibleIds)
+                    ->orWhereIn('target_unit_id', $accessibleIds);
+            })
+            ->get()
+            ->map(function ($link) {
+                return [
+                    'id' => $link->id,
+                    'source_switch' => $link->source_switch,
+                    'target_switch' => $link->target_switch,
+                    'link_type' => $link->link_type,
+                    'vlans' => $link->vlans ?? [],
+                    'distance_km' => $link->distance_km,
+                    'latency_ms' => $link->latency_ms,
+                    'bandwidth_mbps' => $link->bandwidth_mbps,
+                    'is_redundant' => $link->is_redundant,
+                    'source_lat' => $link->sourceUnit->lat ?? null,
+                    'source_lng' => $link->sourceUnit->lng ?? null,
+                    'target_lat' => $link->targetUnit->lat ?? null,
+                    'target_lng' => $link->targetUnit->lng ?? null,
+                ];
+            })->toArray();
+
+        // Load VLANs summary
+        $vlans = Hardware::whereHas('person', function ($q) use ($accessibleIds) {
+            $q->whereIn('u_id', $accessibleIds);
+        })
+            ->whereNotNull('vlan')
+            ->where('vlan', '!=', '')
+            ->pluck('vlan')
+            ->countBy();
+
+        $vlanColors = ['1' => '#e74c3c', '10' => '#3498db', '20' => '#2ecc71', '30' => '#f39c12', '40' => '#9b59b6', '50' => '#1abc9c', '100' => '#e67e22', '200' => '#34495e'];
+        $this->vlans = $vlans->map(fn($count, $vlan) => [
+            'vlan' => (string) $vlan,
+            'count' => $count,
+            'color' => $vlanColors[$vlan] ?? '#' . substr(md5($vlan), 0, 6),
+        ])->values()->toArray();
+
+        // SPOF - switches serving many units
+        $this->spof = $switches->groupBy('switch')->filter(fn($group) => $group->pluck('person.u_id')->unique()->count() >= 3)
+            ->map(function ($group) {
+                $first = $group->first();
+                $unit = $first->person->unit ?? null;
+                $unitCount = $group->pluck('person.u_id')->unique()->count();
+                return [
+                    'name' => $group->first()->switch,
+                    'lat' => $unit->lat ?? null,
+                    'lng' => $unit->lng ?? null,
+                    'unit_name' => $unit->name ?? null,
+                    'unit_count' => $unitCount,
+                    'risk_score' => $unitCount * 10 + $group->count(),
+                ];
+            })
+            ->sortByDesc('risk_score')
+            ->values()->toArray();
+
+        $this->loading = false;
+
+        $this->dispatch('network-map-data-loaded', [
+            'switches' => $this->switches,
+            'links' => $this->links,
+            'vlans' => $this->vlans,
+            'spof' => $this->spof,
+        ]);
+    }
+
+    public function loadStats(): void
+    {
+        $this->stats = [
+            'total_switches' => count($this->switches),
+            'total_links' => count($this->links),
+            'total_vlans' => count($this->vlans),
+            'total_devices' => Hardware::whereHas('person', function ($q) {
+                $accessibleIds = app(AccessService::class)->accessibleUnitIds();
+                $q->whereIn('u_id', $accessibleIds);
+            })->count(),
+            'spof_count' => count($this->spof),
+        ];
+    }
+
+    public function getLinkTypeLabel(string $type): string
+    {
+        return match($type) {
+            'fiber' => 'فایبر نوری',
+            'wireless' => 'بی‌سیم',
+            'mpls' => 'MPLS',
+            'vpn' => 'VPN',
+            default => 'نامشخص',
+        };
+    }
+};
+?>
+
+<div>
+    <x-header title="نقشه تاپولوژی شبکه" separator progress-indicator>
+        <x-slot:actions>
+            <x-help:button section="maps" wireModel="showHelpModal" />
+            <x-theme-selector />
+        </x-slot:actions>
+    </x-header>
+
+    <x-help:modal wireModel="showHelpModal" />
+
+    {{-- Stats bar --}}
+    <div class="grid grid-cols-2 md:grid-cols-5 gap-2 mb-4">
+        <div class="stat bg-base-200 rounded-box p-3 shadow">
+            <div class="stat-title text-xs">سوئیچ‌ها</div>
+            <div class="stat-value text-lg">{{ $stats['total_switches'] ?? 0 }}</div>
+        </div>
+        <div class="stat bg-base-200 rounded-box p-3 shadow">
+            <div class="stat-title text-xs">لینک‌ها</div>
+            <div class="stat-value text-lg">{{ $stats['total_links'] ?? 0 }}</div>
+        </div>
+        <div class="stat bg-base-200 rounded-box p-3 shadow">
+            <div class="stat-title text-xs">VLANها</div>
+            <div class="stat-value text-lg">{{ $stats['total_vlans'] ?? 0 }}</div>
+        </div>
+        <div class="stat bg-base-200 rounded-box p-3 shadow">
+            <div class="stat-title text-xs">تجهیزات</div>
+            <div class="stat-value text-lg">{{ $stats['total_devices'] ?? 0 }}</div>
+        </div>
+        <div class="stat bg-base-200 rounded-box p-3 shadow">
+            <div class="stat-title text-xs">نقاط شکست</div>
+            <div class="stat-value text-lg text-error">{{ $stats['spof_count'] ?? 0 }}</div>
+        </div>
+    </div>
+
+    {{-- Layer controls --}}
+    <x-card shadow class="mb-4 p-3">
+        <div class="flex flex-wrap items-center gap-4">
+            <x-toggle right wire:model.live="showSwitches" label="سوئیچ‌ها" />
+            <x-toggle right wire:model.live="showLinks" label="لینک‌ها" />
+            <x-toggle right wire:model.live="showVlans" label="VLANها" />
+            <x-toggle right wire:model.live="showDevices" label="تجهیزات" />
+            <x-toggle right wire:model.live="showSpof" label="نقاط شکست" />
+
+            <div class="divider divider-horizontal"></div>
+
+            {{-- Link type filter --}}
+            <x-select
+                wire:model.live="selectedLinkType"
+                label="نوع لینک"
+                :options="['' => 'همه', 'fiber' => 'فایبر', 'wireless' => 'بی‌سیم', 'mpls' => 'MPLS', 'vpn' => 'VPN']"
+                class="w-32"
+            />
+
+            <x-button wire:click="loadData" label="بروزرسانی" icon="arrow-path" class="btn-sm btn-primary" />
+        </div>
+    </x-card>
+
+    {{-- Map container --}}
+    <x-card shadow class="p-0">
+        <div class="relative" style="min-height: 600px;">
+            <div id="network-map" style="width: 100%; height: 600px;"></div>
+
+            {{-- Legend sidebar --}}
+            <div class="absolute top-4 right-4 z-10 w-64 space-y-2" x-data="{ open: true }">
+                <button class="btn btn-sm btn-circle btn-ghost bg-base-100/80 shadow" @click="open = !open">
+                    <x-heroicon-o-bars-3 />
+                </button>
+                <div x-show="open" x-transition class="bg-base-100/90 backdrop-blur rounded-box shadow p-3 space-y-3 max-h-[500px] overflow-y-auto">
+                    {{-- VLAN Legend --}}
+                    @if ($showVlans && count($vlans) > 0)
+                        <div>
+                            <h4 class="font-bold text-sm">VLANها</h4>
+                            @foreach ($vlans as $v)
+                                <div class="flex items-center gap-2 text-xs">
+                                    <span class="w-3 h-3 rounded-full" style="background: {{ $v['color'] }}"></span>
+                                    <span>VLAN {{ $v['vlan'] }} ({{ $v['count'] }} دستگاه)</span>
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+
+                    {{-- SPOF List --}}
+                    @if ($showSpof && count($spof) > 0)
+                        <div>
+                            <h4 class="font-bold text-sm text-error">نقاط شکست</h4>
+                            @foreach ($spof as $s)
+                                <div class="text-xs bg-error/10 rounded p-1 mb-1">
+                                    <span class="font-bold">{{ $s['name'] }}</span>
+                                    <span class="text-error">({{ $s['unit_count'] }} واحد)</span>
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </x-card>
+</div>
+
+@assets
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<style>
+    .network-map-tooltip {
+        background: var(--b1);
+        color: var(--bc);
+        padding: 8px 12px;
+        border-radius: 8px;
+        border: 1px solid var(--b3);
+        font-size: 12px;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    }
+    .network-map-tooltip .font-bold { font-weight: 700; }
+</style>
+@endassets
+
+@script
+<script>
+    var map;
+    var layers = {
+        switches: [],
+        links: [],
+        devices: [],
+        spof: [],
+    };
+
+    function initMap() {
+        if (map) return;
+        map = L.map('network-map', { zoomControl: true }).setView([35.5, 48.0], 6);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '© OpenStreetMap contributors',
+            maxZoom: 18,
+        }).addTo(map);
+    }
+
+    function clearLayer(type) {
+        layers[type].forEach(function(layer) { map.removeLayer(layer); });
+        layers[type] = [];
+    }
+
+    function renderSwitches(switches) {
+        clearLayer('switches');
+        if (!@js($showSwitches)) return;
+        switches.forEach(function(sw) {
+            if (!sw.lat || !sw.lng) return;
+            var marker = L.circleMarker([sw.lat, sw.lng], {
+                radius: 6, fillColor: '#3b82f6', color: '#1e40af', weight: 2, fillOpacity: 0.8,
+            }).addTo(map);
+            marker.bindTooltip(
+                '<div class="network-map-tooltip">' +
+                '<div class="font-bold">' + sw.name + '</div>' +
+                '<div>واحد: ' + (sw.unit_name || '-') + '</div>' +
+                '<div>دستگاه‌ها: ' + sw.device_count + '</div>' +
+                '<div>VLAN: ' + (sw.vlans.length > 0 ? sw.vlans.join(', ') : '-') + '</div>' +
+                '</div>'
+            );
+            layers.switches.push(marker);
+        });
+    }
+
+    function renderLinks(links) {
+        clearLayer('links');
+        if (!@js($showLinks)) return;
+        var linkTypeFilter = @js($selectedLinkType);
+        links.forEach(function(link) {
+            if (linkTypeFilter && link.link_type !== linkTypeFilter) return;
+            if (!link.source_lat || !link.target_lat) return;
+            var typeColors = { fiber: '#22c55e', wireless: '#f59e0b', mpls: '#8b5cf6', vpn: '#ec4899', unknown: '#9ca3af' };
+            var color = typeColors[link.link_type] || '#9ca3af';
+            var line = L.polyline([[link.source_lat, link.source_lng], [link.target_lat, link.target_lng]], {
+                color: color, weight: 3, opacity: 0.8,
+                dashArray: link.link_type === 'wireless' ? '5, 10' : null,
+            }).addTo(map);
+            var label = link.link_type === 'fiber' ? 'فایبر' : link.link_type === 'wireless' ? 'بی‌سیم' : link.link_type;
+            line.bindTooltip(
+                '<div class="network-map-tooltip">' +
+                '<div class="font-bold">' + label + '</div>' +
+                '<div>' + link.source_switch + ' → ' + link.target_switch + '</div>' +
+                (link.distance_km ? '<div>فاصله: ' + link.distance_km + ' km</div>' : '') +
+                (link.vlans.length > 0 ? '<div>VLAN: ' + link.vlans.join(', ') + '</div>' : '') +
+                '</div>'
+            );
+            layers.links.push(line);
+        });
+    }
+
+    function renderSpof(spofList) {
+        clearLayer('spof');
+        if (!@js($showSpof)) return;
+        spofList.forEach(function(sp) {
+            if (!sp.lat || !sp.lng) return;
+            var marker = L.circleMarker([sp.lat, sp.lng], {
+                radius: 8, fillColor: '#ef4444', color: '#991b1b', weight: 2, fillOpacity: 0.9,
+            }).addTo(map);
+            marker.bindTooltip(
+                '<div class="network-map-tooltip">' +
+                '<div class="font-bold text-red-600">⚠ ' + sp.name + '</div>' +
+                '<div>واحد: ' + (sp.unit_name || '-') + '</div>' +
+                '<div>تعداد واحدها: ' + sp.unit_count + '</div>' +
+                '<div>امتیاز ریسک: ' + sp.risk_score + '</div>' +
+                '</div>'
+            );
+            layers.spof.push(marker);
+        });
+    }
+
+    // Initialize map
+    initMap();
+
+    // Listen for data updates from Livewire
+    Livewire.on('network-map-data-loaded', function(data) {
+        renderSwitches(data.switches);
+        renderLinks(data.links);
+        renderSpof(data.spof);
+    });
+
+    // Initial render
+    document.addEventListener('DOMContentLoaded', function() {
+        initMap();
+    });
+</script>
+@endscript

--- a/routes/api.php
+++ b/routes/api.php
@@ -102,3 +102,14 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::delete('/todos/{todo}', [TodoController::class, 'destroy']);
     Route::post('/todos/{todo}/toggle-complete', [TodoController::class, 'toggleComplete']);
 });
+
+// Network Map API routes
+Route::middleware('auth:sanctum')->prefix('network-map')->group(function () {
+    Route::get('/switches', [NetworkMapController::class, 'switches']);
+    Route::get('/links', [NetworkMapController::class, 'links']);
+    Route::get('/vlans', [NetworkMapController::class, 'vlans']);
+    Route::get('/spof', [NetworkMapController::class, 'spof']);
+    Route::get('/trace', [NetworkMapController::class, 'trace']);
+    Route::get('/stats', [NetworkMapController::class, 'stats']);
+    Route::get('/devices', [NetworkMapController::class, 'devices']);
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -80,6 +80,7 @@ Route::middleware('auth')->group(function () {
 
             Route::livewire('/it/wireless', 'it/wireless');
             Route::livewire('/it/networks', 'it/networks');
+            Route::livewire('/network-map', 'it.network-map')->name('network-map');
         });
 
         Route::middleware('role_or_permission:calendar')->group(function () {


### PR DESCRIPTION
## Summary

ایجاد صفحه **نقشه تاپولوژی شبکه** (Issue #197) که زیرساخت شبکه را روی نقشه جغرافیایی overlay می‌کند.

## Changes

### Database
- Migration  table: source/target switch, link_type, vlans, distance, latency, bandwidth, redundancy, unit FKs
-  model with relationships

### API (auth:sanctum + organizational scope)
| Endpoint | Description |
|---|---|
| GET /api/network-map/switches | سوئیچ‌ها روی نقشه |
| GET /api/network-map/links | لینک‌های شبکه |
| GET /api/network-map/vlans | خلاصه VLANها با رنگ‌بندی |
| GET /api/network-map/spof | تشخیص نقاط تک‌نقطه شکست |
| GET /api/network-map/trace | مسیریابی بین دو نقطه |
| GET /api/network-map/stats | آمار سراسری شبکه |
| GET /api/network-map/devices | تجهیزات پایانه |

### Livewire Component
- صفحه  با نقشه Leaflet/OpenStreetMap
- کنترل لایه‌ها (سوئیچ‌ها، لینک‌ها، VLANها، تجهیزات، SPOF)
- فیلتر نوع لینک (فایبر/بی‌سیم/MPLS/VPN)
- نوار آمار (سوئیچ، لینک، VLAN، تجهیزات، نقاط شکست)
- جعبه رنگ VLAN و پنل SPOF

### Tests
- 136/136 tests passing (399 assertions)