### PR TITLE
feat: Zabbix Host & Item Configuration Management (Issue #247)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,29 @@ Tracks all modifications to hardware records:
 | GET | `/api/zabbix/traffic` | Network traffic from Zabbix (via `ZabbixService`) |
 | GET | `/api/zabbix/multi-latest` | Multi-item latest values (cached) |
 
+### Zabbix Configuration Management (`/api/zabbix/*`) — #247
+
+Database-backed management of Zabbix hosts, items, and traffic pairs:
+
+**Models:** `ZabbixHost` (`zabbix_hosts`), `ZabbixItem` (`zabbix_items`), `ZabbixItemPair` (`zabbix_item_pairs`)
+- Hosts link to `unit` (org scope) and `hardware` (inventory); items belong to a host with type (`traffic_in/out`, `cpu`, `memory`, `disk`, `custom`); pairs map In/Out items for traffic links
+- All queries respect organizational scope (unit_id null = global, otherwise must be in accessible units)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET/POST | `/api/zabbix/hosts` | List (scoped, filter by status/search) / Create host config |
+| GET/PUT/DELETE | `/api/zabbix/hosts/{host}` | Show with items+pairs / Update / Delete |
+| POST | `/api/zabbix/hosts/{host}/sync` | Trigger Zabbix API discovery and bulk-import items |
+| GET | `/api/zabbix/hosts/{host}/discover` | Discover items from Zabbix API (returns list, marks already-imported) |
+| GET/POST | `/api/zabbix/items` | List items (filter by type/monitored/search) / Create item |
+| GET/PUT/DELETE | `/api/zabbix/items/{item}` | Show / Update / Delete item |
+| POST | `/api/zabbix/items/bulk-sync` | Bulk sync latest values from Zabbix API |
+| GET/POST | `/api/zabbix/pairs` | List traffic pairs / Create pair (validates same-host items) |
+| GET/PUT/DELETE | `/api/zabbix/pairs/{pair}` | Show / Update / Delete pair |
+
+`ZabbixService` extended with `discoverItems($hostId)` and `discoverHosts()` (Zabbix `item.get` / `host.get`).
+Tests: `tests/Feature/ZabbixConfigTest.php` (15 tests: CRUD, scope enforcement, item-host validation).
+
 ---
 
 ## UI Features
@@ -358,6 +381,7 @@ Jalali (Persian) calendar formatting via `Morilog\Jalali\Jalalian` (e.g., in `Re
 - **#217** — Hardware Stats Caching with version-counter invalidation (10-min TTL, driver-agnostic, auto-invalidated on all hardware writes)
 - **#218** — In-app Help System completion (20 content sections, `HelpSystemTest`, Alpine-based modal switching)
 - **#238** — Fixed `Undefined variable $request` in 6 API methods missing the `Request` parameter (`TodoController::toggleComplete/destroy`, `PersonController::destroy`, `TicketController::show/destroy`, `ReportController::units`)
+- **#247** — Zabbix Configuration Management (Models: `ZabbixHost`, `ZabbixItem`, `ZabbixItemPair`; API: CRUD hosts/items/pairs + discover/sync; Scope enforcement; Tests: `ZabbixConfigTest`)
 
 ---
 

--- a/app/Http/Controllers/Api/ZabbixConfigController.php
+++ b/app/Http/Controllers/Api/ZabbixConfigController.php
@@ -1,0 +1,615 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\ZabbixHost;
+use App\Models\ZabbixItem;
+use App\Models\ZabbixItemPair;
+use App\Services\AccessService;
+use App\Services\ZabbixService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+
+class ZabbixConfigController extends Controller
+{
+    protected ZabbixService $zabbixService;
+
+    public function __construct(ZabbixService $zabbixService)
+    {
+        $this->zabbixService = $zabbixService;
+    }
+
+    // ==================== ZABBIX HOSTS ====================
+
+    public function hostsIndex(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($user);
+
+        $query = ZabbixHost::with(['unit:id,name', 'hardware:id,pc_name'])
+            ->where(function ($q) use ($accessibleIds) {
+                $q->whereNull('unit_id')
+                  ->orWhereIn('unit_id', $accessibleIds);
+            });
+
+        // Filters
+        if ($request->filled('status')) {
+            $query->where('status', $request->status);
+        }
+        if ($request->filled('search')) {
+            $s = $request->search;
+            $query->where(function ($q) use ($s) {
+                $q->where('host_name', 'LIKE', "%{$s}%")
+                  ->orWhere('visible_name', 'LIKE', "%{$s}%")
+                  ->orWhere('host_id', 'LIKE', "%{$s}%")
+                  ->orWhere('ip', 'LIKE', "%{$s}%");
+            });
+        }
+
+        $query->orderBy('visible_name');
+
+        $perPage = min((int) $request->get('per_page', 15), 100);
+        $paginator = $query->paginate($perPage);
+
+        return response()->json([
+            'success' => true,
+            'data' => $paginator->items(),
+            'meta' => [
+                'current_page' => $paginator->currentPage(),
+                'last_page' => $paginator->lastPage(),
+                'per_page' => $paginator->perPage(),
+                'total' => $paginator->total(),
+            ],
+        ]);
+    }
+
+    public function hostStore(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'unit_id' => 'nullable|exists:units,id',
+            'hardware_id' => 'nullable|exists:hardwares,id',
+            'host_id' => 'required|string|unique:zabbix_hosts,host_id',
+            'host_name' => 'required|string|max:255',
+            'visible_name' => 'required|string|max:255',
+            'ip' => 'nullable|ip',
+            'description' => 'nullable|string',
+            'status' => 'sometimes|in:active,disabled,maintenance',
+            'template_ids' => 'nullable|array',
+            'template_ids.*' => 'string',
+        ]);
+
+        // Check organizational scope for unit
+        if ($validated['unit_id'] ?? false) {
+            $accessibleIds = app(AccessService::class)->accessibleUnitIds($request->user());
+            if (! in_array($validated['unit_id'], $accessibleIds)) {
+                return response()->json(['message' => 'Unit not accessible.'], 403);
+            }
+        }
+
+        // Check hardware scope
+        if ($validated['hardware_id'] ?? false) {
+            $hardware = \App\Models\Hardware::find($validated['hardware_id']);
+            if ($hardware) {
+                $accessibleIds = app(AccessService::class)->accessibleUnitIds($request->user());
+                $unitId = $hardware->person?->u_id;
+                if ($unitId && ! in_array($unitId, $accessibleIds)) {
+                    return response()->json(['message' => 'Hardware not accessible.'], 403);
+                }
+            }
+        }
+
+        $host = ZabbixHost::create($validated);
+
+        return response()->json([
+            'success' => true,
+            'data' => $host->load(['unit:id,name', 'hardware:id,pc_name']),
+        ], 201);
+    }
+
+    public function hostShow(Request $request, ZabbixHost $host): JsonResponse
+    {
+        // Check organizational scope
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($request->user());
+        if ($host && $host->unit_id && ! in_array($host->unit_id, $accessibleIds)) {
+            return response()->json(['message' => 'Host not accessible.'], 403);
+        }
+
+        $host->load(['unit:id,name', 'hardware:id,pc_name', 'items', 'pairs.outItem', 'pairs.inItem', 'pairs.unit:id,name']);
+
+        return response()->json([
+            'success' => true,
+            'data' => $host,
+        ]);
+    }
+
+    public function hostUpdate(Request $request, ZabbixHost $host): JsonResponse
+    {
+        // Check organizational scope
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($request->user());
+        if ($host && $host->unit_id && ! in_array($host->unit_id, $accessibleIds)) {
+            return response()->json(['message' => 'Host not accessible.'], 403);
+        }
+
+        $validated = $request->validate([
+            'unit_id' => 'nullable|exists:units,id',
+            'hardware_id' => 'nullable|exists:hardwares,id',
+            'host_name' => 'sometimes|required|string|max:255',
+            'visible_name' => 'sometimes|required|string|max:255',
+            'ip' => 'nullable|ip',
+            'description' => 'nullable|string',
+            'status' => 'sometimes|in:active,disabled,maintenance',
+            'template_ids' => 'nullable|array',
+            'template_ids.*' => 'string',
+        ]);
+
+        // Check new unit scope
+        if (isset($validated['unit_id'])) {
+            if ($validated['unit_id'] && ! in_array($validated['unit_id'], $accessibleIds)) {
+                return response()->json(['message' => 'Unit not accessible.'], 403);
+            }
+        }
+
+        $host->update($validated);
+        $host->load(['unit:id,name', 'hardware:id,pc_name']);
+
+        return response()->json([
+            'success' => true,
+            'data' => $host,
+        ]);
+    }
+
+    public function hostDestroy(Request $request, ZabbixHost $host): JsonResponse
+    {
+        // Check organizational scope
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($request->user());
+        if ($host && $host->unit_id && ! in_array($host->unit_id, $accessibleIds)) {
+            return response()->json(['message' => 'Host not accessible.'], 403);
+        }
+
+        $host->delete();
+
+        return response()->json(['success' => true, 'message' => 'Zabbix host deleted.']);
+    }
+
+    // ==================== HOST SYNC & DISCOVER ====================
+
+    public function hostSync(Request $request, ZabbixHost $host): JsonResponse
+    {
+        // Check organizational scope
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($request->user());
+        if ($host && $host->unit_id && ! in_array($host->unit_id, $accessibleIds)) {
+            return response()->json(['message' => 'Host not accessible.'], 403);
+        }
+
+        try {
+            // Discover items from Zabbix API
+            $items = $this->zabbixService->discoverItems($host->host_id);
+
+            $synced = 0;
+            foreach ($items as $item) {
+                ZabbixItem::updateOrCreate(
+                    ['zabbix_host_id' => $host->id, 'item_id' => $item['itemid']],
+                    [
+                        'item_id' => $item['itemid'],
+                        'item_key' => $item['key_'],
+                        'name' => $item['name'],
+                        'type' => $this->guessType($item['key_']),
+                        'unit' => $item['units'] ?? null,
+                        'value_type' => $this->mapValueType($item['value_type'] ?? 0),
+                        'delay' => $item['delay'] ?? '60s',
+                    ]
+                );
+                $synced++;
+            }
+
+            $host->update(['last_sync_at' => now()]);
+
+            return response()->json([
+                'success' => true,
+                'message' => "Discovered and synced {$synced} items from Zabbix.",
+                'synced_count' => $synced,
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Sync failed: ' . $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function hostDiscover(Request $request, ZabbixHost $host): JsonResponse
+    {
+        // Check organizational scope
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($request->user());
+        if ($host && $host->unit_id && ! in_array($host->unit_id, $accessibleIds)) {
+            return response()->json(['message' => 'Host not accessible.'], 403);
+        }
+
+        try {
+            $items = $this->zabbixService->discoverItems($host->host_id);
+
+            $formatted = collect($items)->map(function ($item) {
+                return [
+                    'itemid' => $item['itemid'],
+                    'key_' => $item['key_'],
+                    'name' => $item['name'],
+                    'units' => $item['units'] ?? '',
+                    'type' => $this->guessType($item['key_']),
+                    'value_type' => $this->mapValueType($item['value_type'] ?? 0),
+                    'delay' => $item['delay'] ?? '60s',
+                    'already_imported' => ZabbixItem::where('zabbix_host_id', $host->id)
+                        ->where('item_id', $item['itemid'])
+                        ->exists(),
+                ];
+            })->toArray();
+
+            return response()->json([
+                'success' => true,
+                'data' => $formatted,
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Discovery failed: ' . $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    // ==================== ZABBIX ITEMS ====================
+
+    public function itemsIndex(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($user);
+
+        $query = ZabbixItem::with(['host.unit:id,name', 'host.hardware:id,pc_name'])
+            ->whereHas('host', function ($q) use ($accessibleIds) {
+                $q->whereNull('unit_id')->orWhereIn('unit_id', $accessibleIds);
+            });
+
+        if ($request->filled('type')) {
+            $query->where('type', $request->type);
+        }
+        if ($request->filled('is_monitored')) {
+            $query->where('is_monitored', $request->boolean('is_monitored'));
+        }
+        if ($request->filled('search')) {
+            $s = $request->search;
+            $query->where(function ($q) use ($s) {
+                $q->where('name', 'LIKE', "%{$s}%")
+                  ->orWhere('item_key', 'LIKE', "%{$s}%")
+                  ->orWhere('item_id', 'LIKE', "%{$s}%");
+            });
+        }
+
+        $query->orderBy('display_order')->orderBy('name');
+
+        $perPage = min((int) $request->get('per_page', 15), 100);
+        $paginator = $query->paginate($perPage);
+
+        return response()->json([
+            'success' => true,
+            'data' => $paginator->items(),
+            'meta' => [
+                'current_page' => $paginator->currentPage(),
+                'last_page' => $paginator->lastPage(),
+                'per_page' => $paginator->perPage(),
+                'total' => $paginator->total(),
+            ],
+        ]);
+    }
+
+    public function itemStore(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'zabbix_host_id' => 'required|exists:zabbix_hosts,id',
+            'item_id' => 'required|string|unique:zabbix_items,item_id',
+            'item_key' => 'required|string|max:255',
+            'name' => 'required|string|max:255',
+            'type' => 'sometimes|in:traffic_in,traffic_out,cpu,memory,disk,custom',
+            'unit' => 'nullable|string|max:50',
+            'value_type' => 'sometimes|in:numeric_float,uint,text,log',
+            'delay' => 'sometimes|string|max:50',
+            'is_monitored' => 'boolean',
+            'display_order' => 'integer|min:0',
+        ]);
+
+        // Check host scope
+        $host = ZabbixHost::findOrFail($validated['zabbix_host_id']);
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($request->user());
+        if ($host && $host->unit_id && ! in_array($host->unit_id, $accessibleIds)) {
+            return response()->json(['message' => 'Host not accessible.'], 403);
+        }
+
+        $item = ZabbixItem::create($validated);
+
+        return response()->json([
+            'success' => true,
+            'data' => $item->load('host.unit:id,name'),
+        ], 201);
+    }
+
+    public function itemShow(Request $request, ZabbixItem $item): JsonResponse
+    {
+        // Check organizational scope
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($request->user());
+        $host = $item->host;
+        if ($host && $host->unit_id && ! in_array($host->unit_id, $accessibleIds)) {
+            return response()->json(['message' => 'Item not accessible.'], 403);
+        }
+
+        $item->load(['host.unit:id,name']);
+
+        return response()->json([
+            'success' => true,
+            'data' => $item,
+        ]);
+    }
+
+    public function itemUpdate(Request $request, ZabbixItem $item): JsonResponse
+    {
+        // Check organizational scope
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($request->user());
+        $host = $item->host;
+        if ($host && $host->unit_id && ! in_array($host->unit_id, $accessibleIds)) {
+            return response()->json(['message' => 'Item not accessible.'], 403);
+        }
+
+        $validated = $request->validate([
+            'item_key' => 'sometimes|required|string|max:255',
+            'name' => 'sometimes|required|string|max:255',
+            'type' => 'sometimes|in:traffic_in,traffic_out,cpu,memory,disk,custom',
+            'unit' => 'nullable|string|max:50',
+            'value_type' => 'sometimes|in:numeric_float,uint,text,log',
+            'delay' => 'sometimes|string|max:50',
+            'is_monitored' => 'boolean',
+            'display_order' => 'integer|min:0',
+        ]);
+
+        $item->update($validated);
+
+        return response()->json([
+            'success' => true,
+            'data' => $item->load('host.unit:id,name'),
+        ]);
+    }
+
+    public function itemDestroy(Request $request, ZabbixItem $item): JsonResponse
+    {
+        // Check organizational scope
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($request->user());
+        $host = $item->host;
+        if ($host && $host->unit_id && ! in_array($host->unit_id, $accessibleIds)) {
+            return response()->json(['message' => 'Item not accessible.'], 403);
+        }
+
+        $item->delete();
+
+        return response()->json(['success' => true, 'message' => 'Zabbix item deleted.']);
+    }
+
+    // ==================== BULK SYNC ====================
+
+    public function itemsBulkSync(Request $request): JsonResponse
+    {
+        $request->validate([
+            'item_ids' => 'required|array|min:1',
+            'item_ids.*' => 'string|exists:zabbix_items,item_id',
+        ]);
+
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($request->user());
+
+        // Filter to only accessible items
+        $items = ZabbixItem::whereIn('item_id', $request->item_ids)
+            ->whereHas('host', function ($q) use ($accessibleIds) {
+                $q->whereNull('unit_id')->orWhereIn('unit_id', $accessibleIds);
+            })
+            ->get();
+
+        if ($items->isEmpty()) {
+            return response()->json(['message' => 'No accessible items found.'], 403);
+        }
+
+        $itemIds = $items->pluck('item_id')->toArray();
+        $values = $this->zabbixService->getLatestValues($itemIds);
+
+        $updated = 0;
+        foreach ($items as $item) {
+            $value = $values[$item->item_id] ?? null;
+            if ($value !== null) {
+                $item->update([
+                    'last_value' => $value,
+                    'last_check_at' => now(),
+                ]);
+                $updated++;
+            }
+        }
+
+        return response()->json([
+            'success' => true,
+            'message' => "Synced {$updated} items.",
+            'synced_count' => $updated,
+        ]);
+    }
+
+    // ==================== ZABBIX ITEM PAIRS ====================
+
+    public function pairsIndex(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($user);
+
+        $query = ZabbixItemPair::with([
+            'host.unit:id,name',
+            'outItem',
+            'inItem',
+            'unit:id,name',
+        ])
+            ->where(function ($q) use ($accessibleIds) {
+                $q->whereHas('host', function ($hq) use ($accessibleIds) {
+                    $hq->whereNull('unit_id')->orWhereIn('unit_id', $accessibleIds);
+                });
+            });
+
+        if ($request->filled('is_active')) {
+            $query->where('is_active', $request->boolean('is_active'));
+        }
+
+        $query->orderBy('display_order')->orderBy('name');
+
+        $perPage = min((int) $request->get('per_page', 15), 100);
+        $paginator = $query->paginate($perPage);
+
+        return response()->json([
+            'success' => true,
+            'data' => $paginator->items(),
+            'meta' => [
+                'current_page' => $paginator->currentPage(),
+                'last_page' => $paginator->lastPage(),
+                'per_page' => $paginator->perPage(),
+                'total' => $paginator->total(),
+            ],
+        ]);
+    }
+
+    public function pairStore(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'zabbix_host_id' => 'required|exists:zabbix_hosts,id',
+            'name' => 'required|string|max:255',
+            'out_item_id' => 'required|exists:zabbix_items,id',
+            'in_item_id' => 'required|exists:zabbix_items,id|different:out_item_id',
+            'unit_id' => 'nullable|exists:units,id',
+            'description' => 'nullable|string',
+            'is_active' => 'boolean',
+            'display_order' => 'integer|min:0',
+        ]);
+
+        // Check host scope
+        $host = ZabbixHost::findOrFail($validated['zabbix_host_id']);
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($request->user());
+        if ($host && $host->unit_id && ! in_array($host->unit_id, $accessibleIds)) {
+            return response()->json(['message' => 'Host not accessible.'], 403);
+        }
+
+        // Verify items belong to same host
+        $outItem = ZabbixItem::find($validated['out_item_id']);
+        $inItem = ZabbixItem::find($validated['in_item_id']);
+        if ($outItem->zabbix_host_id !== $host->id || $inItem->zabbix_host_id !== $host->id) {
+            return response()->json(['message' => 'Items must belong to the same host.'], 422);
+        }
+
+        // Check unit scope
+        if ($validated['unit_id'] ?? false) {
+            if (! in_array($validated['unit_id'], $accessibleIds)) {
+                return response()->json(['message' => 'Unit not accessible.'], 403);
+            }
+        }
+
+        $pair = ZabbixItemPair::create($validated);
+
+        return response()->json([
+            'success' => true,
+            'data' => $pair->load(['outItem', 'inItem', 'unit:id,name']),
+        ], 201);
+    }
+
+    public function pairShow(Request $request, ZabbixItemPair $pair): JsonResponse
+    {
+        // Check organizational scope
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($request->user());
+        $host = $pair->host;
+        if ($host && $host->unit_id && ! in_array($host->unit_id, $accessibleIds)) {
+            return response()->json(['message' => 'Pair not accessible.'], 403);
+        }
+
+        $pair->load(['outItem', 'inItem', 'unit:id,name', 'host.unit:id,name']);
+
+        return response()->json([
+            'success' => true,
+            'data' => $pair,
+        ]);
+    }
+
+    public function pairUpdate(Request $request, ZabbixItemPair $pair): JsonResponse
+    {
+        // Check organizational scope
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($request->user());
+        $host = $pair->host;
+        if ($host && $host->unit_id && ! in_array($host->unit_id, $accessibleIds)) {
+            return response()->json(['message' => 'Pair not accessible.'], 403);
+        }
+
+        $validated = $request->validate([
+            'name' => 'sometimes|required|string|max:255',
+            'out_item_id' => 'sometimes|exists:zabbix_items,id',
+            'in_item_id' => 'sometimes|exists:zabbix_items,id|different:out_item_id',
+            'unit_id' => 'nullable|exists:units,id',
+            'description' => 'nullable|string',
+            'is_active' => 'boolean',
+            'display_order' => 'integer|min:0',
+        ]);
+
+        if (isset($validated['unit_id']) && $validated['unit_id'] && ! in_array($validated['unit_id'], $accessibleIds)) {
+            return response()->json(['message' => 'Unit not accessible.'], 403);
+        }
+
+        // Verify items belong to same host if changed
+        if (isset($validated['out_item_id']) || isset($validated['in_item_id'])) {
+            $outItemId = $validated['out_item_id'] ?? $pair->out_item_id;
+            $inItemId = $validated['in_item_id'] ?? $pair->in_item_id;
+            $outItem = ZabbixItem::find($outItemId);
+            $inItem = ZabbixItem::find($inItemId);
+            if ($outItem->zabbix_host_id !== $host->id || $inItem->zabbix_host_id !== $host->id) {
+                return response()->json(['message' => 'Items must belong to the same host.'], 422);
+            }
+        }
+
+        $pair->update($validated);
+
+        return response()->json([
+            'success' => true,
+            'data' => $pair->load(['outItem', 'inItem', 'unit:id,name']),
+        ]);
+    }
+
+    public function pairDestroy(Request $request, ZabbixItemPair $pair): JsonResponse
+    {
+        // Check organizational scope
+        $accessibleIds = app(AccessService::class)->accessibleUnitIds($request->user());
+        $host = $pair->host;
+        if ($host && $host->unit_id && ! in_array($host->unit_id, $accessibleIds)) {
+            return response()->json(['message' => 'Pair not accessible.'], 403);
+        }
+
+        $pair->delete();
+
+        return response()->json(['success' => true, 'message' => 'Traffic pair deleted.']);
+    }
+
+    // ==================== HELPERS ====================
+
+    protected function guessType(string $key): string
+    {
+        if (str_contains($key, 'net.if.in')) return 'traffic_in';
+        if (str_contains($key, 'net.if.out')) return 'traffic_out';
+        if (str_contains($key, 'cpu')) return 'cpu';
+        if (str_contains($key, 'mem')) return 'memory';
+        if (str_contains($key, 'disk') || str_contains($key, 'vfs.fs')) return 'disk';
+        return 'custom';
+    }
+
+    protected function mapValueType(int $type): string
+    {
+        return match ($type) {
+            0 => 'numeric_float',
+            1 => 'text',
+            2 => 'log',
+            3 => 'uint',
+            default => 'numeric_float',
+        };
+    }
+}

--- a/app/Models/ZabbixHost.php
+++ b/app/Models/ZabbixHost.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class ZabbixHost extends Model
+{
+    protected $fillable = [
+        'unit_id',
+        'hardware_id',
+        'host_id',
+        'host_name',
+        'visible_name',
+        'ip',
+        'description',
+        'status',
+        'template_ids',
+        'last_sync_at',
+    ];
+
+    protected $casts = [
+        'template_ids' => 'array',
+        'last_sync_at' => 'datetime',
+    ];
+
+    public function unit(): BelongsTo
+    {
+        return $this->belongsTo(Unit::class);
+    }
+
+    public function hardware(): BelongsTo
+    {
+        return $this->belongsTo(Hardware::class);
+    }
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(ZabbixItem::class);
+    }
+
+    public function pairs(): HasMany
+    {
+        return $this->hasMany(ZabbixItemPair::class);
+    }
+}

--- a/app/Models/ZabbixItem.php
+++ b/app/Models/ZabbixItem.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class ZabbixItem extends Model
+{
+    protected $fillable = [
+        'zabbix_host_id',
+        'item_id',
+        'item_key',
+        'name',
+        'type',
+        'unit',
+        'value_type',
+        'delay',
+        'is_monitored',
+        'display_order',
+        'last_value',
+        'last_check_at',
+    ];
+
+    protected $casts = [
+        'is_monitored' => 'boolean',
+        'last_value' => 'array',
+        'last_check_at' => 'datetime',
+    ];
+
+    public function host(): BelongsTo
+    {
+        return $this->belongsTo(ZabbixHost::class, 'zabbix_host_id');
+    }
+
+    public function outPairs(): HasMany
+    {
+        return $this->hasMany(ZabbixItemPair::class, 'out_item_id');
+    }
+
+    public function inPairs(): HasMany
+    {
+        return $this->hasMany(ZabbixItemPair::class, 'in_item_id');
+    }
+}

--- a/app/Models/ZabbixItemPair.php
+++ b/app/Models/ZabbixItemPair.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ZabbixItemPair extends Model
+{
+    protected $fillable = [
+        'zabbix_host_id',
+        'name',
+        'out_item_id',
+        'in_item_id',
+        'unit_id',
+        'description',
+        'is_active',
+        'display_order',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+    ];
+
+    public function host(): BelongsTo
+    {
+        return $this->belongsTo(ZabbixHost::class, 'zabbix_host_id');
+    }
+
+    public function outItem(): BelongsTo
+    {
+        return $this->belongsTo(ZabbixItem::class, 'out_item_id');
+    }
+
+    public function inItem(): BelongsTo
+    {
+        return $this->belongsTo(ZabbixItem::class, 'in_item_id');
+    }
+
+    public function unit(): BelongsTo
+    {
+        return $this->belongsTo(Unit::class);
+    }
+}

--- a/app/Services/ZabbixService.php
+++ b/app/Services/ZabbixService.php
@@ -71,6 +71,38 @@ class ZabbixService
         return $response['result'][0]['itemid'] ?? null;
     }
 
+    /**
+     * Discover all items for a given Zabbix host.
+     *
+     * @param  string  $hostId  Zabbix host ID
+     * @return array  Array of items with itemid, key_, name, units, value_type, delay
+     */
+    public function discoverItems(string $hostId): array
+    {
+        $response = $this->request('item.get', [
+            'output' => ['itemid', 'key_', 'name', 'units', 'value_type', 'delay', 'hostid'],
+            'hostids' => $hostId,
+            'sortfield' => 'name',
+        ]);
+
+        return $response['result'] ?? [];
+    }
+
+    /**
+     * Get hosts from Zabbix API (for discovery).
+     *
+     * @return array  Array of hosts with hostid, host, name, status
+     */
+    public function discoverHosts(): array
+    {
+        $response = $this->request('host.get', [
+            'output' => ['hostid', 'host', 'name', 'status', 'available'],
+            'sortfield' => 'name',
+        ]);
+
+        return $response['result'] ?? [];
+    }
+
     protected function request($method, $params = [])
     {
         $response = Http::withHeaders([

--- a/database/migrations/2026_08_03_003109_create_zabbix_hosts_table.php
+++ b/database/migrations/2026_08_03_003109_create_zabbix_hosts_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('zabbix_hosts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('unit_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('hardware_id')->nullable()->constrained('hardwares')->nullOnDelete();
+            $table->string('host_id')->unique(); // Zabbix host ID (e.g., 10084)
+            $table->string('host_name'); // Zabbix host name
+            $table->string('visible_name'); // Display name in UI
+            $table->string('ip')->nullable();
+            $table->text('description')->nullable();
+            $table->enum('status', ['active', 'disabled', 'maintenance'])->default('active');
+            $table->json('template_ids')->nullable(); // Associated Zabbix template IDs
+            $table->timestamp('last_sync_at')->nullable();
+            $table->timestamps();
+
+            $table->index('unit_id');
+            $table->index('hardware_id');
+            $table->index('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('zabbix_hosts');
+    }
+};

--- a/database/migrations/2026_08_03_003111_create_zabbix_items_table.php
+++ b/database/migrations/2026_08_03_003111_create_zabbix_items_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('zabbix_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('zabbix_host_id')->constrained()->cascadeOnDelete();
+            $table->string('item_id')->unique(); // Zabbix item ID (e.g., 73638)
+            $table->string('item_key'); // Zabbix item key (e.g., net.if.out[eth0])
+            $table->string('name'); // Display name
+            $table->enum('type', ['traffic_in', 'traffic_out', 'cpu', 'memory', 'disk', 'custom'])->default('custom');
+            $table->string('unit')->nullable(); // Unit of measurement (Mbps, %, GB, etc.)
+            $table->enum('value_type', ['numeric_float', 'uint', 'text', 'log'])->default('numeric_float');
+            $table->string('delay')->default('60s'); // Polling interval (e.g., 60s)
+            $table->boolean('is_monitored')->default(true); // Whether to show in dashboards
+            $table->integer('display_order')->default(0); // Sort order in UI
+            $table->json('last_value')->nullable(); // Cached latest value from Zabbix
+            $table->timestamp('last_check_at')->nullable();
+            $table->timestamps();
+
+            $table->index('zabbix_host_id');
+            $table->index('type');
+            $table->index('is_monitored');
+            $table->index('display_order');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('zabbix_items');
+    }
+};

--- a/database/migrations/2026_08_03_003112_create_zabbix_item_pairs_table.php
+++ b/database/migrations/2026_08_03_003112_create_zabbix_item_pairs_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('zabbix_item_pairs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('zabbix_host_id')->constrained()->cascadeOnDelete();
+            $table->string('name'); // Link name (e.g., "فیبر اصلی", "سوئیچ A")
+            $table->foreignId('out_item_id')->constrained('zabbix_items')->cascadeOnDelete();
+            $table->foreignId('in_item_id')->constrained('zabbix_items')->cascadeOnDelete();
+            $table->foreignId('unit_id')->nullable()->constrained()->nullOnDelete(); // Organizational scope
+            $table->text('description')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->integer('display_order')->default(0);
+            $table->timestamps();
+
+            $table->index('zabbix_host_id');
+            $table->index('unit_id');
+            $table->index('is_active');
+            $table->index('display_order');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('zabbix_item_pairs');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Api\TodoController;
 use App\Http\Controllers\Api\PersonController;
 use App\Http\Controllers\Api\TrafficController;
 use App\Http\Controllers\Api\UnitController;
+use App\Http\Controllers\Api\ZabbixConfigController;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
@@ -48,6 +49,33 @@ Route::middleware('auth:sanctum')->group(function () {
 
 Route::middleware('auth:sanctum')->get('/zabbix/traffic', [TrafficController::class, 'index']);
 Route::middleware('auth:sanctum')->get('/zabbix/multi-latest', [MultiLatestValueController::class, 'index']);
+
+// Zabbix Configuration Management (Issue #247)
+Route::middleware('auth:sanctum')->prefix('zabbix')->group(function () {
+    // Hosts
+    Route::get('/hosts', [ZabbixConfigController::class, 'hostsIndex']);
+    Route::post('/hosts', [ZabbixConfigController::class, 'hostStore']);
+    Route::get('/hosts/{host}', [ZabbixConfigController::class, 'hostShow']);
+    Route::put('/hosts/{host}', [ZabbixConfigController::class, 'hostUpdate']);
+    Route::delete('/hosts/{host}', [ZabbixConfigController::class, 'hostDestroy']);
+    Route::post('/hosts/{host}/sync', [ZabbixConfigController::class, 'hostSync']);
+    Route::get('/hosts/{host}/discover', [ZabbixConfigController::class, 'hostDiscover']);
+
+    // Items
+    Route::get('/items', [ZabbixConfigController::class, 'itemsIndex']);
+    Route::post('/items', [ZabbixConfigController::class, 'itemStore']);
+    Route::get('/items/{item}', [ZabbixConfigController::class, 'itemShow']);
+    Route::put('/items/{item}', [ZabbixConfigController::class, 'itemUpdate']);
+    Route::delete('/items/{item}', [ZabbixConfigController::class, 'itemDestroy']);
+    Route::post('/items/bulk-sync', [ZabbixConfigController::class, 'itemsBulkSync']);
+
+    // Pairs
+    Route::get('/pairs', [ZabbixConfigController::class, 'pairsIndex']);
+    Route::post('/pairs', [ZabbixConfigController::class, 'pairStore']);
+    Route::get('/pairs/{pair}', [ZabbixConfigController::class, 'pairShow']);
+    Route::put('/pairs/{pair}', [ZabbixConfigController::class, 'pairUpdate']);
+    Route::delete('/pairs/{pair}', [ZabbixConfigController::class, 'pairDestroy']);
+});
 
 // Hardware API routes
 Route::middleware('auth:sanctum')->prefix('hardware')->group(function () {

--- a/tests/Feature/ZabbixConfigTest.php
+++ b/tests/Feature/ZabbixConfigTest.php
@@ -1,0 +1,385 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Hardware;
+use App\Models\Person;
+use App\Models\Unit;
+use App\Models\User;
+use App\Models\ZabbixHost;
+use App\Models\ZabbixItem;
+use App\Models\ZabbixItemPair;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Session;
+use Tests\TestCase;
+
+class ZabbixConfigTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $tId;
+    protected $eId;
+    protected $sId;
+    protected $rId;
+    protected $unit;
+    protected $user;
+    protected $host;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Session::flush();
+
+        $this->tId = DB::table('tahsils')->insertGetId(['name' => 'Test']);
+        $this->eId = DB::table('estekhdams')->insertGetId(['name' => 'Test']);
+        $this->sId = DB::table('semats')->insertGetId(['name' => 'Test']);
+        $this->rId = DB::table('radifs')->insertGetId(['name' => 'Test']);
+
+        $nCode = (string) random_int(1000000000, 2147483647);
+        $this->unit = Unit::create(['name' => 'Test Unit']);
+        Person::create([
+            'n_code' => $nCode,
+            'f_name' => 'Test',
+            'l_name' => 'User',
+            't_id' => $this->tId,
+            'e_id' => $this->eId,
+            's_id' => $this->sId,
+            'r_id' => $this->rId,
+            'u_id' => $this->unit->id,
+        ]);
+        $this->user = User::create([
+            'n_code' => $nCode,
+            'password' => Hash::make('password'),
+        ]);
+        $this->user->units()->attach($this->unit->id, ['role' => 'staff', 'is_primary' => true]);
+        Session::put('current_unit_id', $this->unit->id);
+
+        // Create a Zabbix host in the user's unit
+        $this->host = ZabbixHost::create([
+            'unit_id' => $this->unit->id,
+            'host_id' => '10084',
+            'host_name' => 'core-switch-01',
+            'visible_name' => 'سوئیچ اصلی',
+            'ip' => '192.168.1.1',
+            'status' => 'active',
+        ]);
+    }
+
+    protected function authHeaders(): array
+    {
+        $token = $this->user->createToken('test')->plainTextToken;
+        return ['Authorization' => 'Bearer ' . $token];
+    }
+
+    public function test_unauthenticated_user_cannot_access_zabbix_config(): void
+    {
+        $this->getJson('/api/zabbix/hosts')->assertStatus(401);
+        $this->getJson('/api/zabbix/items')->assertStatus(401);
+        $this->getJson('/api/zabbix/pairs')->assertStatus(401);
+    }
+
+    public function test_hosts_index_returns_scoped_hosts(): void
+    {
+        $response = $this->withHeaders($this->authHeaders())->getJson('/api/zabbix/hosts');
+
+        $response->assertStatus(200)
+            ->assertJson(['success' => true]);
+        $this->assertEquals(1, $response->json('meta.total'));
+        $this->assertEquals('سوئیچ اصلی', $response->json('data.0.visible_name'));
+    }
+
+    public function test_hosts_index_excludes_inaccessible_hosts(): void
+    {
+        // Create host in another unit
+        $otherUnit = Unit::create(['name' => 'Other Unit']);
+        ZabbixHost::create([
+            'unit_id' => $otherUnit->id,
+            'host_id' => '99999',
+            'host_name' => 'other-host',
+            'visible_name' => 'هاست دیگر',
+            'status' => 'active',
+        ]);
+
+        $response = $this->withHeaders($this->authHeaders())->getJson('/api/zabbix/hosts');
+
+        $response->assertStatus(200);
+        $this->assertEquals(1, $response->json('meta.total'));
+    }
+
+    public function test_host_store_creates_host(): void
+    {
+        $response = $this->withHeaders($this->authHeaders())->postJson('/api/zabbix/hosts', [
+            'unit_id' => $this->unit->id,
+            'host_id' => '20000',
+            'host_name' => 'new-host',
+            'visible_name' => 'هاست جدید',
+            'ip' => '10.0.0.5',
+            'status' => 'active',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJson(['success' => true]);
+        $this->assertDatabaseHas('zabbix_hosts', ['host_id' => '20000']);
+    }
+
+    public function test_host_store_rejects_inaccessible_unit(): void
+    {
+        $otherUnit = Unit::create(['name' => 'Other Unit']);
+
+        $response = $this->withHeaders($this->authHeaders())->postJson('/api/zabbix/hosts', [
+            'unit_id' => $otherUnit->id,
+            'host_id' => '20001',
+            'host_name' => 'blocked-host',
+            'visible_name' => 'هاست ممنوع',
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_host_show_returns_items_and_pairs(): void
+    {
+        $item1 = ZabbixItem::create([
+            'zabbix_host_id' => $this->host->id,
+            'item_id' => '73638',
+            'item_key' => 'net.if.out[eth0]',
+            'name' => 'خروجی اترنت',
+            'type' => 'traffic_out',
+            'unit' => 'bps',
+        ]);
+        $item2 = ZabbixItem::create([
+            'zabbix_host_id' => $this->host->id,
+            'item_id' => '73639',
+            'item_key' => 'net.if.in[eth0]',
+            'name' => 'ورودی اترنت',
+            'type' => 'traffic_in',
+            'unit' => 'bps',
+        ]);
+        ZabbixItemPair::create([
+            'zabbix_host_id' => $this->host->id,
+            'name' => 'فیبر اصلی',
+            'out_item_id' => $item1->id,
+            'in_item_id' => $item2->id,
+            'unit_id' => $this->unit->id,
+            'is_active' => true,
+        ]);
+
+        $response = $this->withHeaders($this->authHeaders())->getJson("/api/zabbix/hosts/{$this->host->id}");
+
+        $response->assertStatus(200)
+            ->assertJson(['success' => true]);
+        $this->assertEquals(2, count($response->json('data.items')));
+        $this->assertEquals(1, count($response->json('data.pairs')));
+        $this->assertEquals('فیبر اصلی', $response->json('data.pairs.0.name'));
+    }
+
+    public function test_host_update_changes_fields(): void
+    {
+        $response = $this->withHeaders($this->authHeaders())->putJson("/api/zabbix/hosts/{$this->host->id}", [
+            'visible_name' => 'سوئیچ اصلی ۲',
+            'status' => 'maintenance',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJson(['success' => true]);
+        $this->assertDatabaseHas('zabbix_hosts', [
+            'id' => $this->host->id,
+            'visible_name' => 'سوئیچ اصلی ۲',
+            'status' => 'maintenance',
+        ]);
+    }
+
+    public function test_host_destroy_deletes_host(): void
+    {
+        $response = $this->withHeaders($this->authHeaders())->deleteJson("/api/zabbix/hosts/{$this->host->id}");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('zabbix_hosts', ['id' => $this->host->id]);
+    }
+
+    public function test_item_store_and_index(): void
+    {
+        $response = $this->withHeaders($this->authHeaders())->postJson('/api/zabbix/items', [
+            'zabbix_host_id' => $this->host->id,
+            'item_id' => '73640',
+            'item_key' => 'system.cpu.load',
+            'name' => 'بار پردازنده',
+            'type' => 'cpu',
+            'unit' => '%',
+            'is_monitored' => true,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJson(['success' => true]);
+
+        $list = $this->withHeaders($this->authHeaders())->getJson('/api/zabbix/items');
+        $list->assertStatus(200);
+        $this->assertEquals(1, $list->json('meta.total'));
+        $this->assertEquals('بار پردازنده', $list->json('data.0.name'));
+    }
+
+    public function test_item_update_toggles_monitored(): void
+    {
+        $item = ZabbixItem::create([
+            'zabbix_host_id' => $this->host->id,
+            'item_id' => '73641',
+            'item_key' => 'system.cpu.load',
+            'name' => 'CPU Load',
+            'type' => 'cpu',
+            'is_monitored' => true,
+        ]);
+
+        $response = $this->withHeaders($this->authHeaders())->putJson("/api/zabbix/items/{$item->id}", [
+            'is_monitored' => false,
+            'display_order' => 5,
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJson(['success' => true]);
+        $this->assertDatabaseHas('zabbix_items', [
+            'id' => $item->id,
+            'is_monitored' => false,
+            'display_order' => 5,
+        ]);
+    }
+
+    public function test_item_destroy_deletes_item(): void
+    {
+        $item = ZabbixItem::create([
+            'zabbix_host_id' => $this->host->id,
+            'item_id' => '73642',
+            'item_key' => 'test.key',
+            'name' => 'Test Item',
+            'type' => 'custom',
+        ]);
+
+        $response = $this->withHeaders($this->authHeaders())->deleteJson("/api/zabbix/items/{$item->id}");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('zabbix_items', ['id' => $item->id]);
+    }
+
+    public function test_pairs_index_returns_traffic_pairs(): void
+    {
+        $outItem = ZabbixItem::create([
+            'zabbix_host_id' => $this->host->id,
+            'item_id' => '73650',
+            'item_key' => 'net.if.out[eth0]',
+            'name' => 'Out',
+            'type' => 'traffic_out',
+        ]);
+        $inItem = ZabbixItem::create([
+            'zabbix_host_id' => $this->host->id,
+            'item_id' => '73651',
+            'item_key' => 'net.if.in[eth0]',
+            'name' => 'In',
+            'type' => 'traffic_in',
+        ]);
+        ZabbixItemPair::create([
+            'zabbix_host_id' => $this->host->id,
+            'name' => 'لینک اصلی',
+            'out_item_id' => $outItem->id,
+            'in_item_id' => $inItem->id,
+            'unit_id' => $this->unit->id,
+            'is_active' => true,
+            'display_order' => 1,
+        ]);
+
+        $response = $this->withHeaders($this->authHeaders())->getJson('/api/zabbix/pairs');
+
+        $response->assertStatus(200)
+            ->assertJson(['success' => true]);
+        $this->assertEquals(1, $response->json('meta.total'));
+        $this->assertEquals('لینک اصلی', $response->json('data.0.name'));
+        $this->assertEquals('Out', $response->json('data.0.out_item.name'));
+        $this->assertEquals('In', $response->json('data.0.in_item.name'));
+    }
+
+    public function test_pair_store_validates_items_same_host(): void
+    {
+        // Create item on a DIFFERENT host
+        $otherHost = ZabbixHost::create([
+            'unit_id' => $this->unit->id,
+            'host_id' => '30000',
+            'host_name' => 'other',
+            'visible_name' => 'دیگر',
+            'status' => 'active',
+        ]);
+        $outItem = ZabbixItem::create([
+            'zabbix_host_id' => $this->host->id,
+            'item_id' => '73660',
+            'item_key' => 'net.if.out[eth1]',
+            'name' => 'Out1',
+            'type' => 'traffic_out',
+        ]);
+        $inItem = ZabbixItem::create([
+            'zabbix_host_id' => $otherHost->id,
+            'item_id' => '73661',
+            'item_key' => 'net.if.in[eth1]',
+            'name' => 'In1',
+            'type' => 'traffic_in',
+        ]);
+
+        $response = $this->withHeaders($this->authHeaders())->postJson('/api/zabbix/pairs', [
+            'zabbix_host_id' => $this->host->id,
+            'name' => 'Pair Invalid',
+            'out_item_id' => $outItem->id,
+            'in_item_id' => $inItem->id,
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_pair_destroy_deletes_pair(): void
+    {
+        $outItem = ZabbixItem::create([
+            'zabbix_host_id' => $this->host->id,
+            'item_id' => '73670',
+            'item_key' => 'net.if.out[eth2]',
+            'name' => 'Out2',
+            'type' => 'traffic_out',
+        ]);
+        $inItem = ZabbixItem::create([
+            'zabbix_host_id' => $this->host->id,
+            'item_id' => '73671',
+            'item_key' => 'net.if.in[eth2]',
+            'name' => 'In2',
+            'type' => 'traffic_in',
+        ]);
+        $pair = ZabbixItemPair::create([
+            'zabbix_host_id' => $this->host->id,
+            'name' => 'Pair To Delete',
+            'out_item_id' => $outItem->id,
+            'in_item_id' => $inItem->id,
+        ]);
+
+        $response = $this->withHeaders($this->authHeaders())->deleteJson("/api/zabbix/pairs/{$pair->id}");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('zabbix_item_pairs', ['id' => $pair->id]);
+    }
+
+    public function test_scope_enforced_on_other_unit_host(): void
+    {
+        $otherUnit = Unit::create(['name' => 'Other Unit']);
+        $otherHost = ZabbixHost::create([
+            'unit_id' => $otherUnit->id,
+            'host_id' => '40000',
+            'host_name' => 'blocked-host',
+            'visible_name' => 'هاست دیگر',
+            'status' => 'active',
+        ]);
+
+        $response = $this->withHeaders($this->authHeaders())->getJson("/api/zabbix/hosts/{$otherHost->id}");
+        $response->assertStatus(403);
+
+        $response = $this->withHeaders($this->authHeaders())->putJson("/api/zabbix/hosts/{$otherHost->id}", [
+            'visible_name' => 'Hacked',
+        ]);
+        $response->assertStatus(403);
+
+        $response = $this->withHeaders($this->authHeaders())->deleteJson("/api/zabbix/hosts/{$otherHost->id}");
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Zabbix Configuration Management** (Issue #247) — database-backed management of Zabbix hosts, items, and traffic pairs with full API support.

### Database
- `zabbix_hosts` — hosts linked to unit (org scope) + hardware inventory
- `zabbix_items` — items with type (traffic_in/out, cpu, memory, disk, custom), monitored flag, cached last_value
- `zabbix_item_pairs` — In/Out traffic pairs (validates same-host items)

### Models
- `ZabbixHost`, `ZabbixItem`, `ZabbixItemPair` with full relationships

### API (all scoped by organizational unit)
- Hosts: CRUD + `/sync` (bulk-import from Zabbix API) + `/discover`
- Items: CRUD + `/bulk-sync` (latest values)
- Pairs: CRUD

### ZabbixService
- Added `discoverItems()` and `discoverHosts()`

### Tests
- `tests/Feature/ZabbixConfigTest.php` — 15 tests (CRUD, scope enforcement, same-host validation)
- Full suite: **151 passed, 444 assertions**

Closes #247