### PR TITLE
fix: CI — postgis extension in migration + pest --mutate for mutation job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,21 @@ jobs:
 
   mutation:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgis/postgis:16-3.4
+        env:
+          POSTGRES_PASSWORD: secret
+          POSTGRES_DB: h_dashboard_test
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:latest
+        ports: ['6379:6379']
     steps:
       - uses: actions/checkout@v4
       - name: Setup PHP
@@ -58,4 +73,4 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
       - name: Run mutation tests
-        run: ./vendor/bin/infection --min-msi=80 --min-covered-msi=80
+        run: ./vendor/bin/pest --mutate --min=80 --covered-only --parallel

--- a/database/migrations/2025_03_20_000009_create_boundaries_table.php
+++ b/database/migrations/2025_03_20_000009_create_boundaries_table.php
@@ -2,12 +2,21 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
     public function up(): void
     {
+        // PostGIS must exist before creating geometry columns. On CI the
+        // database is created from the plain postgis image template (no
+        // template_postgis), so enable the extension explicitly here —
+        // NOT in a later migration (2026_08_03) which runs AFTER this table.
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('CREATE EXTENSION IF NOT EXISTS postgis;');
+        }
+
         Schema::create('boundaries', function (Blueprint $table) {
             $table->id();
             $table->geometry('boundary', 'MULTIPOLYGON')->srid(4326);


### PR DESCRIPTION
## Problem

CI has been **failing on every run** (30+ consecutive failures, both jobs) — merge is always blocked.

### 1. test job — `type "geometry" does not exist`
`./vendor/bin/pest --parallel --coverage --min=80` creates fresh per-process databases (`h_dashboard_test_test_1`, `_2`, ...). These have **no PostGIS**: the `postgis/postgis` image only applies the extension to the `POSTGRES_DB` database via its init template. The `boundaries` migration creates a `geometry` column before any `CREATE EXTENSION postgis` runs (the extension is only created in a *later* migration, `2026_08_03_004321`).

### 2. mutation job — `./vendor/bin/infection: No such file or directory`
The workflow calls Infection, but `infection/infection` was **never in composer.json** → exit 127 on every run.

## Fix

- **`database/migrations/2025_03_20_000009_create_boundaries_table.php`**: runs `CREATE EXTENSION IF NOT EXISTS postgis` (pgsql only) **before** creating the geometry column, so fresh parallel databases migrate cleanly.
- **`.github/workflows/test.yml`**:
  - mutation job now uses Pest's native mutation testing: `./vendor/bin/pest --mutate --min=80 --covered-only --parallel` (Pest ≥ 4 ships mutation testing; Infection has no Pest adapter).
  - mutation job now has postgres + redis services (it runs the full suite, previously had none).

## Verification
- Fresh database without template_postgis: `migrate:fresh` now completes (boundaries + all migrations OK, postgis extension present).
- Full suite after the change: **695 passed, 1 skipped** (1664 assertions).